### PR TITLE
Refactor rendering logic to outside of the Environment class.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 import pytest
 
@@ -14,6 +14,9 @@ class DummyState(NamedTuple):
 
 
 class DummyEnv(jit_env.Environment):
+
+    def __init__(self):
+        super().__init__(renderer=lambda *_: jax.numpy.ones(()))
 
     def reset(
             self,
@@ -41,9 +44,6 @@ class DummyEnv(jit_env.Environment):
 
     def action_spec(self) -> specs.Spec:
         return specs.Array((), float, 'action')
-
-    def render(self, state: jit_env.State) -> Any:
-        return jax.numpy.ones(())
 
 
 @pytest.fixture

--- a/jit_env/_core.py
+++ b/jit_env/_core.py
@@ -261,8 +261,7 @@ class Environment(Generic[State, Action, Observation], metaclass=abc.ABCMeta):
                 If no renderer is provided to Environment.
         """
         if self._renderer is None:
-            # pragma: no cover
-            raise NotImplementedError(
+            raise NotImplementedError(  # pragma: no cover
                 "Render Function not Implemented"
             )
         return self._renderer(state)

--- a/jit_env/_wrappers_test.py
+++ b/jit_env/_wrappers_test.py
@@ -11,7 +11,7 @@ from jit_env import wrappers, specs
 class TestRepr:
 
     def test_empty(self, dummy_env: jit_env.Environment):
-        wrapped = jit_env.Wrapper(dummy_env)
+        wrapped: jit_env.Wrapper = jit_env.Wrapper(dummy_env)
 
         assert str(wrapped) == f'{wrapped.__class__.__name__}(' \
                                f'{dummy_env.__class__.__name__})'


### PR DESCRIPTION
This PR reduces coupling of the base Environment API while maintaining feature parity with libraries like `jumanji` or `gymnasium`.

This changes the constructor of `Environment` with a keyword argument `renderer`. This slight change should not take away from the classical `dm_env` API.