### PR TITLE
Include StopGrad convenience wrapper and explicitly imports TypeVars.

### DIFF
--- a/jit_env/__init__.py
+++ b/jit_env/__init__.py
@@ -3,12 +3,14 @@
 Private attributes (starting with '_') should not be accessed lest thou would
 risketh the consequences of internal API changes.
 """
-from typing import Union as _Alias_Union
-from typing_extensions import TypeAlias as _TypeAlias
-
 from jit_env.version import __version__, __version_info__
 
 from jit_env import _core
+from jit_env._core import (
+    Action as Action,
+    State as State,
+    Observation as Observation
+)
 
 from jit_env import specs
 from jit_env import wrappers
@@ -18,12 +20,6 @@ Environment = _core.Environment
 Wrapper = _core.Wrapper
 StepType = _core.StepType
 TimeStep = _core.TimeStep
-
-# Type Annotations/ Alias defined as a type Union to distinguish Variables
-# from an Alias: https://github.com/python/mypy/issues/3494
-Action: _TypeAlias = _Alias_Union[_core.Action]
-State: _TypeAlias = _Alias_Union[_core.State]
-Observation: _TypeAlias = _Alias_Union[_core.Observation]
 
 # Helper functions for creating TimeStep namedtuples with default settings.
 restart = _core.restart

--- a/jit_env/_wrappers_test.py
+++ b/jit_env/_wrappers_test.py
@@ -1,4 +1,5 @@
 from dataclasses import replace
+
 import pytest
 
 import chex
@@ -65,14 +66,17 @@ def test_unwrap(dummy_env: jit_env.Environment):
 
 
 @pytest.mark.usefixtures('dummy_env')
-def test_jit(dummy_env: jit_env.Environment):
+def test_jit(
+        dummy_env: jit_env.Environment[
+            jit_env.State, jax.Array, jit_env.Observation
+        ]
+):
     jitted = wrappers.Jit(dummy_env)
-
-    # Reset logic
 
     # For type checker
     jit_state: jit_env.State
 
+    # Reset logic
     state, step = dummy_env.reset(jax.random.PRNGKey(0))
     jit_state, jit_step = jitted.reset(jax.random.PRNGKey(0))
 
@@ -101,7 +105,6 @@ def test_jit(dummy_env: jit_env.Environment):
 
 @pytest.mark.usefixtures('dummy_env')
 def test_stopgrad(dummy_env: jit_env.Environment):
-
     class ScaleRewardWrapper(jit_env.Wrapper):
 
         def step(
@@ -190,15 +193,20 @@ def test_autoreset(dummy_env: jit_env.Environment):
 class TestVmap:
 
     @pytest.mark.usefixtures('dummy_env')
-    def test_env(self, dummy_env: jit_env.Environment, batch_size: int = 5):
+    def test_env(
+            self,
+            dummy_env: jit_env.Environment[
+                jit_env.State, jax.Array, jit_env.Observation
+            ],
+            batch_size: int = 5
+    ):
         key = jax.random.PRNGKey(0)
         batched = wrappers.Vmap(dummy_env)
-
-        # Reset logic
 
         # For type checker
         states: jit_env.State
 
+        # Reset logic
         state, step = dummy_env.reset(key)
         states, steps = batched.reset(jax.random.split(key, num=batch_size))
 
@@ -225,7 +233,13 @@ class TestVmap:
         )
 
     @pytest.mark.usefixtures('dummy_env')
-    def test_render(self, dummy_env: jit_env.Environment, batch_size: int = 5):
+    def test_render(
+            self,
+            dummy_env: jit_env.Environment[
+                jit_env.State, jit_env.Action, jit_env.Observation
+            ],
+            batch_size: int = 5
+    ):
         key = jax.random.PRNGKey(0)
         batched = wrappers.Vmap(dummy_env)
 
@@ -246,7 +260,12 @@ class TestVmap:
         )
 
     @pytest.mark.usefixtures('dummy_env')
-    def test_wrongly_wrapped_autoreset(self, dummy_env: jit_env.Environment):
+    def test_wrongly_wrapped_autoreset(
+            self,
+            dummy_env: jit_env.Environment[
+                jit_env.State, jit_env.Action, jit_env.Observation
+            ]
+    ):
         vmap_first = wrappers.AutoReset(wrappers.Vmap(dummy_env))
         vmap_last = wrappers.Vmap(wrappers.AutoReset(dummy_env))
 
@@ -262,7 +281,13 @@ class TestVmap:
         vmap_last.step(last, jnp.zeros((5,)))
 
     @pytest.mark.usefixtures('dummy_env')
-    def test_autoreset(self, dummy_env: jit_env.Environment, num: int = 2):
+    def test_autoreset(
+            self,
+            dummy_env: jit_env.Environment[
+                jit_env.State, jit_env.Action, jit_env.Observation
+            ],
+            num: int = 2
+    ):
         # Doubly or single-wrapping should both work.
         # Singly is preferred as it is faster, this is not explicitly tested.
         doubly_wrapped = wrappers.Vmap(
@@ -363,7 +388,13 @@ class TestTile:
         )
 
     @pytest.mark.usefixtures('dummy_env')
-    def test_autoreset(self, dummy_env: jit_env.Environment, num: int = 2):
+    def test_autoreset(
+            self,
+            dummy_env: jit_env.Environment[
+                jit_env.State, jit_env.Action, jit_env.Observation
+            ],
+            num: int = 2
+    ):
         # Tile and Vmap are equivalent aside from the `reset` call.
         vmapped = wrappers.VmapAutoReset(dummy_env, in_axes=(0, None))
         tiled = wrappers.TileAutoReset(dummy_env, num=num, in_axes=(0, None))

--- a/jit_env/wrappers.py
+++ b/jit_env/wrappers.py
@@ -116,6 +116,19 @@ class Vmap(_core.Wrapper):
         return super().render(state_0)
 
 
+class StopGradient(_core.Wrapper):
+    """Wrapper to cancel out all Env-dependent gradients."""
+
+    def step(
+            self,
+            state: _core.State,
+            action: _core.Action
+    ) -> tuple[_core.State, _core.TimeStep]:
+        return _jax.tree_map(
+            _jax.lax.stop_gradient, super().step(state, action)
+        )
+
+
 class BatchSpecMixin:
     """Provide a fixed-size batched environment-spec as a MixIn."""
     env: _core.Environment


### PR DESCRIPTION
This PR should solve both #14 and #15. 

We added a dummy test for the StopGrad wrapper. Type hints regarding `State`, `Observation`, and `Action` can now be explicitly parameterized in either `jit_env.Environment` or `jit_env.Wrapper`.