### PR TITLE
ExtendObservation Wrapper

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,7 +20,9 @@ class DummyEnv(jit_env.Environment):
 
     def reset(
             self,
-            key: jax.random.KeyArray
+            key: jax.random.KeyArray,
+            *,
+            options: jit_env.EnvOptions = None
     ) -> tuple[DummyState, jit_env.TimeStep]:
         return DummyState(key=key), jit_env.restart(jax.numpy.zeros(()))
 

--- a/examples/counting_env.py
+++ b/examples/counting_env.py
@@ -42,7 +42,9 @@ class CountingEnv(
 
     def reset(
             self,
-            key: PRNGKeyArray
+            key: PRNGKeyArray,
+            *,
+            options=None
     ) -> tuple[MyState, jit_env.TimeStep]:
         state = MyState(key=key, count=jnp.zeros((), jnp.int32))
         return state, jit_env.restart(state.count, shape=())

--- a/jit_env/__init__.py
+++ b/jit_env/__init__.py
@@ -11,7 +11,8 @@ from jit_env._core import (
     State as State,
     Observation as Observation,
     RewardT as Reward,
-    DiscountT as Discount
+    DiscountT as Discount,
+    EnvOptions
 )
 
 from jit_env import specs

--- a/jit_env/compat.py
+++ b/jit_env/compat.py
@@ -88,10 +88,13 @@ def make_deepmind_wrapper() -> None | tuple[type, _typing.Callable]:
         def __init__(
                 self,
                 env: _core.Environment,
-                rng: _jax.random.KeyArray = _jax.random.PRNGKey(0)
+                rng: _jax.random.KeyArray = _jax.random.PRNGKey(0),
+                *,
+                options: _core.EnvOptions = None
         ):
             self.env = env
             self.rng = rng
+            self.options = options
 
             self._state = None
 
@@ -101,7 +104,7 @@ def make_deepmind_wrapper() -> None | tuple[type, _typing.Callable]:
 
         def reset(self) -> dm_env.TimeStep:
             self.rng, key = _jax.random.split(self.rng)
-            self._state, step = self.env.reset(key)
+            self._state, step = self.env.reset(key, options=self.options)
             return dm_env.restart(step.observation)
 
         def step(self, action) -> dm_env.TimeStep:
@@ -248,7 +251,7 @@ def make_gymnasium_wrapper() -> None | tuple[type, _typing.Callable]:
                 self._seed(seed)
 
             self.rng, reset_key = _jax.random.split(self.rng)
-            self.env_state, step = self.env.reset(reset_key)
+            self.env_state, step = self.env.reset(reset_key, options=options)
 
             return step.observation, (step.extras or {})
 


### PR DESCRIPTION
Implement ExtendObservation with the POMDP fields as a special case. Implement tests for functionality.

Ready to merge for now. In the future this might be reworked due to Python typing updates.